### PR TITLE
Add MSDF text rendering (Font2D, Text shader, Vulkan fixes)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "UHE/vendor/jolt"]
 	path = UHE/vendor/jolt
 	url = https://github.com/jrouwe/JoltPhysics.git
+[submodule "UHE/vendor/msdf-atlas-gen"]
+	path = UHE/vendor/msdf-atlas-gen
+	url = https://github.com/Chlumsky/msdf-atlas-gen.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,13 @@ add_subdirectory(UHE/vendor/yaml-cpp)
 add_subdirectory(UHE/vendor/box2d)
 add_subdirectory(UHE/vendor/fastgltf)
 
+# MSDF text rendering (msdf-atlas-gen + msdfgen)
+set(MSDF_ATLAS_USE_VCPKG OFF        CACHE BOOL "" FORCE)
+set(MSDF_ATLAS_USE_SKIA  OFF        CACHE BOOL "" FORCE)
+set(MSDF_ATLAS_BUILD_STANDALONE OFF CACHE BOOL "" FORCE)
+set(MSDF_ATLAS_NO_ARTERY_FONT ON    CACHE BOOL "" FORCE)
+add_subdirectory(UHE/vendor/msdf-atlas-gen)
+
 # Disable Jolt Physics tests and viewers to drastically reduce compile times
 set(TARGET_UNIT_TESTS OFF CACHE BOOL "" FORCE)
 set(TARGET_HELLO_WORLD OFF CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,21 @@ endfunction()
 # all libs
 add_subdirectory(UHE/vendor/GLFW)
 
-add_subdirectory(UHE/vendor/imgui)
+# ImGui is built here instead of add_subdirectory(UHE/vendor/imgui): the vendored
+# fork's CMakeLists.txt defines IMGUI_API=__declspec(dllexport) unconditionally,
+# which breaks GCC/Linux builds
+add_library(ImGui STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/UHE/vendor/imgui/imgui.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/UHE/vendor/imgui/imgui_draw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/UHE/vendor/imgui/imgui_tables.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/UHE/vendor/imgui/imgui_widgets.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/UHE/vendor/imgui/imgui_demo.cpp
+)
+if(MSVC)
+    target_compile_definitions(ImGui PRIVATE IMGUI_API=__declspec\(dllexport\))
+endif()
+target_include_directories(ImGui PUBLIC UHE/vendor/imgui)
+
 add_subdirectory(UHE/vendor/imGuizmo)
 add_subdirectory(UHE/vendor/volk)
 add_subdirectory(UHE/vendor/VulkanMemoryAllocator)

--- a/UHE/CMakeLists.txt
+++ b/UHE/CMakeLists.txt
@@ -102,6 +102,7 @@ PRIVATE
     slang::slang
     box2d
     Jolt
+    msdf-atlas-gen
 )
 
 if(UNIX)

--- a/UHE/src/Platform/Vulkan/VulkanExtensionCheck.cpp
+++ b/UHE/src/Platform/Vulkan/VulkanExtensionCheck.cpp
@@ -252,9 +252,12 @@ vk::PhysicalDeviceFeatures2* VulkanExtensionCheck::BuildDeviceFeatureChain()
     }
     if (m_extensionCheck.HasVkfragment_shading_rate)
     {
-        m_fragmentShadingRateFeatures.pipelineFragmentShadingRate = VK_TRUE;
-        m_fragmentShadingRateFeatures.primitiveFragmentShadingRate = VK_TRUE;
-        m_fragmentShadingRateFeatures.attachmentFragmentShadingRate = VK_TRUE;
+        m_fragmentShadingRateFeatures.pipelineFragmentShadingRate =
+            m_supportedFragmentShadingRateFeatures.pipelineFragmentShadingRate;
+        m_fragmentShadingRateFeatures.primitiveFragmentShadingRate =
+            m_supportedFragmentShadingRateFeatures.primitiveFragmentShadingRate;
+        m_fragmentShadingRateFeatures.attachmentFragmentShadingRate =
+            m_supportedFragmentShadingRateFeatures.attachmentFragmentShadingRate;
         *pNextChainTail = &m_fragmentShadingRateFeatures;
         pNextChainTail = &m_fragmentShadingRateFeatures.pNext;
     }
@@ -306,6 +309,14 @@ vk::PhysicalDeviceFeatures2* VulkanExtensionCheck::BuildDeviceFeatureChain()
     *pNextChainTail = nullptr;
     return &m_features2;
 };
+
+void VulkanExtensionCheck::QuerySupportedFeatures(const vk::raii::PhysicalDevice& PhysicalDevice)
+{
+    m_supportedFragmentShadingRateFeatures.pNext = nullptr;
+    m_features2.pNext = m_extensionCheck.HasVkfragment_shading_rate ? &m_supportedFragmentShadingRateFeatures : nullptr;
+    vkGetPhysicalDeviceFeatures2(*PhysicalDevice, reinterpret_cast<VkPhysicalDeviceFeatures2*>(&m_features2));
+    m_features2.pNext = nullptr;
+}
 
 void VulkanExtensionCheck::TickTheAvailableExtension(const vk::raii::PhysicalDevice& PhysicalDevice)
 {

--- a/UHE/src/Platform/Vulkan/VulkanExtensionCheck.cpp
+++ b/UHE/src/Platform/Vulkan/VulkanExtensionCheck.cpp
@@ -312,10 +312,13 @@ vk::PhysicalDeviceFeatures2* VulkanExtensionCheck::BuildDeviceFeatureChain()
 
 void VulkanExtensionCheck::QuerySupportedFeatures(const vk::raii::PhysicalDevice& PhysicalDevice)
 {
+    if (!m_extensionCheck.HasVkfragment_shading_rate)
+        return;
+
+    vk::PhysicalDeviceFeatures2 queryFeatures2;
     m_supportedFragmentShadingRateFeatures.pNext = nullptr;
-    m_features2.pNext = m_extensionCheck.HasVkfragment_shading_rate ? &m_supportedFragmentShadingRateFeatures : nullptr;
-    vkGetPhysicalDeviceFeatures2(*PhysicalDevice, reinterpret_cast<VkPhysicalDeviceFeatures2*>(&m_features2));
-    m_features2.pNext = nullptr;
+    queryFeatures2.pNext = &m_supportedFragmentShadingRateFeatures;
+    vkGetPhysicalDeviceFeatures2(*PhysicalDevice, reinterpret_cast<VkPhysicalDeviceFeatures2*>(&queryFeatures2));
 }
 
 void VulkanExtensionCheck::TickTheAvailableExtension(const vk::raii::PhysicalDevice& PhysicalDevice)

--- a/UHE/src/Platform/Vulkan/VulkanExtensionCheck.h
+++ b/UHE/src/Platform/Vulkan/VulkanExtensionCheck.h
@@ -94,6 +94,7 @@ public:
     [[nodiscard]] std::vector<const char*> GetEnabledDeviceExtensions() const;
     [[nodiscard]] vk::PhysicalDeviceFeatures2* BuildDeviceFeatureChain();
     void TickTheAvailableExtension(const vk::raii::PhysicalDevice& PhysicalDevice);
+    void QuerySupportedFeatures(const vk::raii::PhysicalDevice& PhysicalDevice);
 
 private:
     VulkanExtensionIsEnableCheck m_extensionCheck;
@@ -111,6 +112,7 @@ private:
     vk::PhysicalDeviceRayTracingPipelineFeaturesKHR m_rayTracingPipelineFeatures;
     vk::PhysicalDeviceRayQueryFeaturesKHR m_rayQueryFeatures;
     vk::PhysicalDeviceFragmentShadingRateFeaturesKHR m_fragmentShadingRateFeatures;
+    vk::PhysicalDeviceFragmentShadingRateFeaturesKHR m_supportedFragmentShadingRateFeatures;
     vk::PhysicalDeviceCooperativeMatrixFeaturesKHR m_cooperativeMatrixFeatures;
     vk::PhysicalDeviceRobustness2FeaturesEXT m_robustness2Features;
     vk::PhysicalDeviceMemoryPriorityFeaturesEXT m_memoryPriorityFeatures;

--- a/UHE/src/Platform/Vulkan/VulkanLogicalDevice.cpp
+++ b/UHE/src/Platform/Vulkan/VulkanLogicalDevice.cpp
@@ -32,6 +32,7 @@ void VulkanLogicalDevice::initialize(VulkanPhysicalDevice& physicalDevice, VkSur
     }
 
     CheckExtens.TickTheAvailableExtension(phyDevice);
+    CheckExtens.QuerySupportedFeatures(phyDevice);
     auto deviceExtensions = CheckExtens.GetEnabledDeviceExtensions();
 
     float queuePriority = 1.0f;
@@ -52,6 +53,7 @@ void VulkanLogicalDevice::initialize(VulkanPhysicalDevice& physicalDevice, VkSur
 
     m_logicalDevice = vk::raii::Device(phyDevice, deviceCreateInfo);
     volkLoadDevice(*m_logicalDevice);
+    VULKAN_HPP_DEFAULT_DISPATCHER.init(*instance.getInstance(), *m_logicalDevice);
     m_graphicsQueue = vk::raii::Queue(m_logicalDevice, m_graphicsQueueFamilyIndex, 0);
 
     VmaVulkanFunctions vulkanFunctions{.vkGetInstanceProcAddr = vkGetInstanceProcAddr,

--- a/UHE/src/UHE/Renderer/Font.cpp
+++ b/UHE/src/UHE/Renderer/Font.cpp
@@ -13,6 +13,9 @@
 #include "msdfgen.h"
 #include "msdfgen-ext.h"
 
+#include <algorithm>
+#include <thread>
+
 namespace UHE {
 
 struct Font2D::Impl
@@ -27,10 +30,8 @@ struct Font2D::Impl
 };
 
 template <typename T, typename S, int N, msdf_atlas::GeneratorFunction<S, N> GenFunc>
-static RHI::TextureHandle CreateAndCacheAtlas(const std::string& fontName, double fontSize,
-                                              const std::vector<msdf_atlas::GlyphGeometry>& glyphs,
-                                              const msdf_atlas::FontGeometry& fontGeometry, uint32_t width,
-                                              uint32_t height)
+static RHI::TextureHandle CreateAtlasTexture(const std::vector<msdf_atlas::GlyphGeometry>& glyphs, uint32_t width,
+                                             uint32_t height)
 {
     msdf_atlas::GeneratorAttributes attributes;
     attributes.config.overlapSupport = true;
@@ -38,7 +39,8 @@ static RHI::TextureHandle CreateAndCacheAtlas(const std::string& fontName, doubl
 
     msdf_atlas::ImmediateAtlasGenerator<S, N, GenFunc, msdf_atlas::BitmapAtlasStorage<T, N>> generator(width, height);
     generator.setAttributes(attributes);
-    generator.setThreadCount(8);
+    unsigned hwThreads = std::thread::hardware_concurrency();
+    generator.setThreadCount((int)std::max(1u, std::min(8u, hwThreads ? hwThreads : 1u)));
     generator.generate(glyphs.data(), (int)glyphs.size());
 
     msdfgen::BitmapConstSection<T, N> bitmap = (msdfgen::BitmapConstSection<T, N>)generator.atlasStorage();
@@ -58,12 +60,17 @@ Font2D::Font2D(const std::string& ttfPath, u32 genSizePx, f32 pixelRange)
     : m_Path(ttfPath), m_GenSizePx(genSizePx), m_PixelRange(pixelRange), m_Impl(std::make_unique<Impl>())
 {
     msdfgen::FreetypeHandle* ft = msdfgen::initializeFreetype();
-    UHE_CORE_ASSERT(ft);
+    if (!ft)
+    {
+        UHE_CORE_ERROR("Failed to initialize FreeType for font: {}", m_Path);
+        return;
+    }
 
     msdfgen::FontHandle* font = msdfgen::loadFont(ft, m_Path.c_str());
     if (!font)
     {
         UHE_CORE_ERROR("Failed to load font: {}", m_Path);
+        msdfgen::deinitializeFreetype(ft);
         return;
     }
 
@@ -84,6 +91,13 @@ Font2D::Font2D(const std::string& ttfPath, u32 genSizePx, f32 pixelRange)
     double fontScale = 1.0;
     int glyphsLoaded = m_Impl->FontGeometry.loadCharset(font, fontScale, charset);
     UHE_CORE_INFO("Loaded {} glyphs from font (out of {})", glyphsLoaded, charset.size());
+    if (glyphsLoaded <= 0)
+    {
+        UHE_CORE_ERROR("No glyphs loaded from font: {}", m_Path);
+        msdfgen::destroyFont(font);
+        msdfgen::deinitializeFreetype(ft);
+        return;
+    }
 
     double emSize = (double)m_GenSizePx;
 
@@ -92,11 +106,16 @@ Font2D::Font2D(const std::string& ttfPath, u32 genSizePx, f32 pixelRange)
     atlasPacker.setMiterLimit(1.0);
     atlasPacker.setScale(emSize);
     int remaining = atlasPacker.pack(m_Impl->Glyphs.data(), (int)m_Impl->Glyphs.size());
-    UHE_CORE_ASSERT(remaining == 0);
+    if (remaining != 0)
+    {
+        UHE_CORE_ERROR("Atlas packing failed for font {}: {} glyphs did not fit", m_Path, remaining);
+        msdfgen::destroyFont(font);
+        msdfgen::deinitializeFreetype(ft);
+        return;
+    }
 
     int width, height;
     atlasPacker.getDimensions(width, height);
-    emSize = atlasPacker.getScale();
     m_AtlasWidth = (u32)width;
     m_AtlasHeight = (u32)height;
 
@@ -106,13 +125,18 @@ Font2D::Font2D(const std::string& ttfPath, u32 genSizePx, f32 pixelRange)
     unsigned long long glyphSeed = 0;
     for (msdf_atlas::GlyphGeometry& glyph : m_Impl->Glyphs)
     {
-        glyphSeed *= LCG_MULTIPLIER;
+        glyphSeed = glyphSeed * LCG_MULTIPLIER + LCG_INCREMENT;
         glyph.edgeColoring(msdfgen::edgeColoringInkTrap, DEFAULT_ANGLE_THRESHOLD, glyphSeed);
     }
 
-    m_Atlas = CreateAndCacheAtlas<uint8_t, float, 4, msdf_atlas::mtsdfGenerator>(
-        m_Path, emSize, m_Impl->Glyphs, m_Impl->FontGeometry, width, height);
-    UHE_CORE_ASSERT(m_Atlas, "Failed to create MSDF atlas!");
+    m_Atlas = CreateAtlasTexture<uint8_t, float, 4, msdf_atlas::mtsdfGenerator>(m_Impl->Glyphs, width, height);
+    if (!m_Atlas)
+    {
+        UHE_CORE_ERROR("Failed to create MSDF atlas for font: {}", m_Path);
+        msdfgen::destroyFont(font);
+        msdfgen::deinitializeFreetype(ft);
+        return;
+    }
 
     const msdfgen::FontMetrics& metrics = m_Impl->FontGeometry.getMetrics();
     m_Ascent = (f32)metrics.ascenderY;
@@ -132,12 +156,14 @@ Font2D::Font2D(const std::string& ttfPath, u32 genSizePx, f32 pixelRange)
         FontGlyph fontGlyph;
         fontGlyph.PlaneBoundsMin = {(f32)planeL, (f32)planeB};
         fontGlyph.PlaneBoundsMax = {(f32)planeR, (f32)planeT};
-        fontGlyph.UVMin = {(f32)atlasL / (f32)m_AtlasWidth, (f32)atlasB / (f32)m_AtlasHeight};
-        fontGlyph.UVMax = {(f32)atlasR / (f32)m_AtlasWidth, (f32)atlasT / (f32)m_AtlasHeight};
+        fontGlyph.UVMin = {(f32)atlasL / (f32)m_AtlasWidth, 1.0f - (f32)atlasT / (f32)m_AtlasHeight};
+        fontGlyph.UVMax = {(f32)atlasR / (f32)m_AtlasWidth, 1.0f - (f32)atlasB / (f32)m_AtlasHeight};
         fontGlyph.Advance = (f32)glyph.getAdvance();
 
         m_Glyphs.emplace((u32)codepoint, fontGlyph);
     }
+
+    m_Valid = true;
 
     UHE_CORE_INFO("Font loaded: {}, {} glyphs, atlas {}x{}", m_Path, (u32)m_Glyphs.size(), m_AtlasWidth,
                   m_AtlasHeight);
@@ -146,7 +172,11 @@ Font2D::Font2D(const std::string& ttfPath, u32 genSizePx, f32 pixelRange)
     msdfgen::deinitializeFreetype(ft);
 }
 
-Font2D::~Font2D() = default;
+Font2D::~Font2D()
+{
+    if (m_Atlas)
+        Renderer::GetDevice().DestroyTexture(m_Atlas);
+}
 
 Ref<Font2D> Font2D::Get(const std::string& ttfPath, u32 genSizePx)
 {
@@ -156,16 +186,29 @@ Ref<Font2D> Font2D::Get(const std::string& ttfPath, u32 genSizePx)
         return it->second;
 
     Ref<Font2D> font = CreateRef<Font2D>(ttfPath, genSizePx);
+    if (!font->IsValid())
+    {
+        UHE_CORE_ERROR("Failed to create font: {} (not cached)", ttfPath);
+        return nullptr;
+    }
+
     s_Cache[key] = font;
     return font;
 }
 
 Ref<Font2D> Font2D::GetDefault()
 {
-    static Ref<Font2D> s_DefaultFont;
     if (!s_DefaultFont)
+    {
         s_DefaultFont = Get((FileSystem::Get().GetRootPath() / "assets/fonts/Inter_18pt-Bold.ttf").string());
+    }
     return s_DefaultFont;
+}
+
+void Font2D::Shutdown()
+{
+    s_DefaultFont.reset();
+    s_Cache.clear();
 }
 
 const FontGlyph* Font2D::GetGlyph(u32 codepoint) const
@@ -177,5 +220,6 @@ const FontGlyph* Font2D::GetGlyph(u32 codepoint) const
 }
 
 std::unordered_map<std::string, Ref<Font2D>> Font2D::s_Cache;
+Ref<Font2D> Font2D::s_DefaultFont;
 
 } // namespace UHE

--- a/UHE/src/UHE/Renderer/Font.cpp
+++ b/UHE/src/UHE/Renderer/Font.cpp
@@ -1,0 +1,181 @@
+#include "uhepch.h"
+#include "Font.h"
+
+#include "UHE/Renderer/Renderer.h"
+#include "UHE/RHI/RHIDevice.h"
+#include "UHE/RHI/RHICommadBuffer.h"
+#include "UHE/AssestsManager/VfsSystem.h"
+
+#include "msdf-atlas-gen/msdf-atlas-gen.h"
+#include "msdf-atlas-gen/FontGeometry.h"
+#include "msdf-atlas-gen/GlyphGeometry.h"
+
+#include "msdfgen.h"
+#include "msdfgen-ext.h"
+
+namespace UHE {
+
+struct Font2D::Impl
+{
+    std::vector<msdf_atlas::GlyphGeometry> Glyphs;
+    msdf_atlas::FontGeometry FontGeometry;
+
+    Impl()
+        : FontGeometry(&Glyphs)
+    {
+    }
+};
+
+template <typename T, typename S, int N, msdf_atlas::GeneratorFunction<S, N> GenFunc>
+static RHI::TextureHandle CreateAndCacheAtlas(const std::string& fontName, double fontSize,
+                                              const std::vector<msdf_atlas::GlyphGeometry>& glyphs,
+                                              const msdf_atlas::FontGeometry& fontGeometry, uint32_t width,
+                                              uint32_t height)
+{
+    msdf_atlas::GeneratorAttributes attributes;
+    attributes.config.overlapSupport = true;
+    attributes.scanlinePass = true;
+
+    msdf_atlas::ImmediateAtlasGenerator<S, N, GenFunc, msdf_atlas::BitmapAtlasStorage<T, N>> generator(width, height);
+    generator.setAttributes(attributes);
+    generator.setThreadCount(8);
+    generator.generate(glyphs.data(), (int)glyphs.size());
+
+    msdfgen::BitmapConstSection<T, N> bitmap = (msdfgen::BitmapConstSection<T, N>)generator.atlasStorage();
+
+    auto& device = Renderer::GetDevice();
+    RHI::TextureDesc texDesc{};
+    texDesc.width = width;
+    texDesc.height = height;
+    texDesc.format = RHI::TextureFormat::RGBA8_UNORM;
+    texDesc.usage = RHI::TextureUsage::Sampled | RHI::TextureUsage::TransferDst;
+    RHI::TextureHandle texture = device.CreateTexture(texDesc);
+    device.GetCurrentCommandBuffer().UpdateTexture(texture, (void*)bitmap.pixels, width * height * N);
+    return texture;
+}
+
+Font2D::Font2D(const std::string& ttfPath, u32 genSizePx, f32 pixelRange)
+    : m_Path(ttfPath), m_GenSizePx(genSizePx), m_PixelRange(pixelRange), m_Impl(std::make_unique<Impl>())
+{
+    msdfgen::FreetypeHandle* ft = msdfgen::initializeFreetype();
+    UHE_CORE_ASSERT(ft);
+
+    msdfgen::FontHandle* font = msdfgen::loadFont(ft, m_Path.c_str());
+    if (!font)
+    {
+        UHE_CORE_ERROR("Failed to load font: {}", m_Path);
+        return;
+    }
+
+    struct CharsetRange
+    {
+        uint32_t Begin, End;
+    };
+
+    static const CharsetRange charsetRanges[] = {{0x0020, 0x00FF}};
+
+    msdf_atlas::Charset charset;
+    for (CharsetRange range : charsetRanges)
+    {
+        for (uint32_t c = range.Begin; c <= range.End; c++)
+            charset.add(c);
+    }
+
+    double fontScale = 1.0;
+    int glyphsLoaded = m_Impl->FontGeometry.loadCharset(font, fontScale, charset);
+    UHE_CORE_INFO("Loaded {} glyphs from font (out of {})", glyphsLoaded, charset.size());
+
+    double emSize = (double)m_GenSizePx;
+
+    msdf_atlas::TightAtlasPacker atlasPacker;
+    atlasPacker.setPixelRange(m_PixelRange);
+    atlasPacker.setMiterLimit(1.0);
+    atlasPacker.setScale(emSize);
+    int remaining = atlasPacker.pack(m_Impl->Glyphs.data(), (int)m_Impl->Glyphs.size());
+    UHE_CORE_ASSERT(remaining == 0);
+
+    int width, height;
+    atlasPacker.getDimensions(width, height);
+    emSize = atlasPacker.getScale();
+    m_AtlasWidth = (u32)width;
+    m_AtlasHeight = (u32)height;
+
+    constexpr double DEFAULT_ANGLE_THRESHOLD = 3.0;
+    constexpr unsigned long long LCG_MULTIPLIER = 6364136223846793005ull;
+    constexpr unsigned long long LCG_INCREMENT = 1442695040888963407ull;
+    unsigned long long glyphSeed = 0;
+    for (msdf_atlas::GlyphGeometry& glyph : m_Impl->Glyphs)
+    {
+        glyphSeed *= LCG_MULTIPLIER;
+        glyph.edgeColoring(msdfgen::edgeColoringInkTrap, DEFAULT_ANGLE_THRESHOLD, glyphSeed);
+    }
+
+    m_Atlas = CreateAndCacheAtlas<uint8_t, float, 4, msdf_atlas::mtsdfGenerator>(
+        m_Path, emSize, m_Impl->Glyphs, m_Impl->FontGeometry, width, height);
+    UHE_CORE_ASSERT(m_Atlas, "Failed to create MSDF atlas!");
+
+    const msdfgen::FontMetrics& metrics = m_Impl->FontGeometry.getMetrics();
+    m_Ascent = (f32)metrics.ascenderY;
+    m_LineHeight = (f32)metrics.lineHeight;
+
+    for (const msdf_atlas::GlyphGeometry& glyph : m_Impl->Glyphs)
+    {
+        int codepoint = glyph.getIdentifier(msdf_atlas::GlyphIdentifierType::UNICODE_CODEPOINT);
+        if (codepoint < 0)
+            continue;
+
+        double planeL, planeB, planeR, planeT;
+        glyph.getQuadPlaneBounds(planeL, planeB, planeR, planeT);
+        double atlasL, atlasB, atlasR, atlasT;
+        glyph.getQuadAtlasBounds(atlasL, atlasB, atlasR, atlasT);
+
+        FontGlyph fontGlyph;
+        fontGlyph.PlaneBoundsMin = {(f32)planeL, (f32)planeB};
+        fontGlyph.PlaneBoundsMax = {(f32)planeR, (f32)planeT};
+        fontGlyph.UVMin = {(f32)atlasL / (f32)m_AtlasWidth, (f32)atlasB / (f32)m_AtlasHeight};
+        fontGlyph.UVMax = {(f32)atlasR / (f32)m_AtlasWidth, (f32)atlasT / (f32)m_AtlasHeight};
+        fontGlyph.Advance = (f32)glyph.getAdvance();
+
+        m_Glyphs.emplace((u32)codepoint, fontGlyph);
+    }
+
+    UHE_CORE_INFO("Font loaded: {}, {} glyphs, atlas {}x{}", m_Path, (u32)m_Glyphs.size(), m_AtlasWidth,
+                  m_AtlasHeight);
+
+    msdfgen::destroyFont(font);
+    msdfgen::deinitializeFreetype(ft);
+}
+
+Font2D::~Font2D() = default;
+
+Ref<Font2D> Font2D::Get(const std::string& ttfPath, u32 genSizePx)
+{
+    std::string key = ttfPath + "#" + std::to_string(genSizePx);
+    auto it = s_Cache.find(key);
+    if (it != s_Cache.end())
+        return it->second;
+
+    Ref<Font2D> font = CreateRef<Font2D>(ttfPath, genSizePx);
+    s_Cache[key] = font;
+    return font;
+}
+
+Ref<Font2D> Font2D::GetDefault()
+{
+    static Ref<Font2D> s_DefaultFont;
+    if (!s_DefaultFont)
+        s_DefaultFont = Get((FileSystem::Get().GetRootPath() / "assets/fonts/Inter_18pt-Bold.ttf").string());
+    return s_DefaultFont;
+}
+
+const FontGlyph* Font2D::GetGlyph(u32 codepoint) const
+{
+    auto it = m_Glyphs.find(codepoint);
+    if (it != m_Glyphs.end())
+        return &it->second;
+    return nullptr;
+}
+
+std::unordered_map<std::string, Ref<Font2D>> Font2D::s_Cache;
+
+} // namespace UHE

--- a/UHE/src/UHE/Renderer/Font.h
+++ b/UHE/src/UHE/Renderer/Font.h
@@ -22,8 +22,16 @@ public:
     Font2D(const std::string& ttfPath, u32 genSizePx = 64, f32 pixelRange = 2.0f);
     ~Font2D();
 
+    Font2D(const Font2D&) = delete;
+    Font2D& operator=(const Font2D&) = delete;
+    Font2D(Font2D&&) = delete;
+    Font2D& operator=(Font2D&&) = delete;
+
     static Ref<Font2D> Get(const std::string& ttfPath, u32 genSizePx = 64);
     static Ref<Font2D> GetDefault();
+    static void Shutdown();
+
+    bool IsValid() const { return m_Valid; }
 
     const FontGlyph* GetGlyph(u32 codepoint) const;
     f32 GetAscent() const { return m_Ascent; }
@@ -42,12 +50,14 @@ private:
     f32 m_LineHeight = 0.0f;
     u32 m_AtlasWidth = 0;
     u32 m_AtlasHeight = 0;
+    bool m_Valid = false;
     RHI::TextureHandle m_Atlas = nullptr;
     std::unordered_map<u32, FontGlyph> m_Glyphs;
 
     struct Impl;
     std::unique_ptr<Impl> m_Impl;
     static std::unordered_map<std::string, Ref<Font2D>> s_Cache;
+    static Ref<Font2D> s_DefaultFont;
 };
 
 } // namespace UHE

--- a/UHE/src/UHE/Renderer/Font.h
+++ b/UHE/src/UHE/Renderer/Font.h
@@ -1,0 +1,53 @@
+#pragma once
+#include "uhepch.h"
+#include "UHE/Core/Core.h"
+#include "UHE/RHI/RHITypes.h"
+#include <glm/glm.hpp>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace UHE {
+
+struct UHE_API FontGlyph
+{
+    glm::vec2 PlaneBoundsMin, PlaneBoundsMax;
+    glm::vec2 UVMin, UVMax;
+    f32 Advance = 0.0f;
+};
+
+class UHE_API Font2D
+{
+public:
+    Font2D(const std::string& ttfPath, u32 genSizePx = 64, f32 pixelRange = 2.0f);
+    ~Font2D();
+
+    static Ref<Font2D> Get(const std::string& ttfPath, u32 genSizePx = 64);
+    static Ref<Font2D> GetDefault();
+
+    const FontGlyph* GetGlyph(u32 codepoint) const;
+    f32 GetAscent() const { return m_Ascent; }
+    f32 GetLineHeight() const { return m_LineHeight; }
+    f32 GetPixelRange() const { return m_PixelRange; }
+
+    RHI::TextureHandle GetAtlas() const { return m_Atlas; }
+    u32 GetAtlasWidth() const { return m_AtlasWidth; }
+    u32 GetAtlasHeight() const { return m_AtlasHeight; }
+
+private:
+    std::string m_Path;
+    u32 m_GenSizePx;
+    f32 m_PixelRange;
+    f32 m_Ascent = 0.0f;
+    f32 m_LineHeight = 0.0f;
+    u32 m_AtlasWidth = 0;
+    u32 m_AtlasHeight = 0;
+    RHI::TextureHandle m_Atlas = nullptr;
+    std::unordered_map<u32, FontGlyph> m_Glyphs;
+
+    struct Impl;
+    std::unique_ptr<Impl> m_Impl;
+    static std::unordered_map<std::string, Ref<Font2D>> s_Cache;
+};
+
+} // namespace UHE

--- a/UHE/src/UHE/Renderer/Renderer2D.cpp
+++ b/UHE/src/UHE/Renderer/Renderer2D.cpp
@@ -7,6 +7,7 @@
 #include "UHE/RHI/RHIDevice.h"
 #include "UHE/Renderer/Renderer.h"
 #include "UHE/Renderer/SlangCompiler.h"
+#include "UHE/Renderer/Font.h"
 #include "UHE/Scene/Components.h"
 
 namespace UHE
@@ -171,6 +172,7 @@ void Renderer2D::Shutdown()
 {
     UHE_PROFILE_FUNCTION();
     auto& device = Renderer::GetDevice();
+    Font2D::Shutdown();
     delete[] s_Data.QuadVertexBufferBase;
     device.DestroyGraphicsPipeline(s_Data.QuadPipeline);
     device.DestroyShader(s_Data.QuadVertexShader);

--- a/UHE/src/UHE/Renderer3D/Renderer3D.cpp
+++ b/UHE/src/UHE/Renderer3D/Renderer3D.cpp
@@ -1,11 +1,11 @@
 #include "uhepch.h"
 #include "Renderer3D.h"
-#include "UHE/Renderer/Renderer.h"
-#include "UHE/RHI/RHIDevice.h"
-#include "UHE/RHI/RHICommadBuffer.h"
-#include "UHE/Renderer/SlangCompiler.h"
-#include "UHE/AssestsManager/VfsSystem.h"
 #include <glm/gtc/matrix_transform.hpp>
+#include "UHE/AssestsManager/VfsSystem.h"
+#include "UHE/RHI/RHICommadBuffer.h"
+#include "UHE/RHI/RHIDevice.h"
+#include "UHE/Renderer/Renderer.h"
+#include "UHE/Renderer/SlangCompiler.h"
 
 namespace UHE
 {
@@ -15,23 +15,23 @@ struct Renderer3DData
     RHI::ShaderHandle VertexShader;
     RHI::ShaderHandle FragmentShader;
     RHI::PipelineHandle ModelPipeline;
-    
+
     RHI::ShaderHandle GridVertexShader;
     RHI::ShaderHandle GridFragmentShader;
     RHI::PipelineHandle GridPipeline;
-    
+
     glm::mat4 ViewProjection;
     glm::vec3 CameraPosition;
     std::vector<RD3d::LightData> CurrentLights;
     Ref<Texture2D> WhiteTexture;
-    
+
     RHI::BufferHandle LightStorageBufferHandle = nullptr;
     uint32_t LightStorageBufferIndex = 0;
-    
+
     RHI::BufferHandle BoneStorageBufferHandle = nullptr;
     uint32_t BoneStorageBufferIndex = 0;
     uint32_t BoneBufferOffset = 0; // In number of matrices
-    
+
     bool EnableLighting = true;
 };
 
@@ -40,7 +40,7 @@ static Renderer3DData s_Data3D;
 void Renderer3D::Init()
 {
     auto& device = Renderer::GetDevice();
-    
+
     std::string shaderPath = (FileSystem::Get().GetRootPath() / "assets/shaders/Basic3D.slang").string();
     auto compiledShaders = SlangCompiler::CompileToSPIRV(shaderPath);
 
@@ -65,14 +65,12 @@ void Renderer3D::Init()
     RHI::GraphicsPipelineDesc pipeDesc{};
     pipeDesc.vertexShader = s_Data3D.VertexShader;
     pipeDesc.fragmentShader = s_Data3D.FragmentShader;
-    pipeDesc.vertexLayout = {
-        {RHI::ShaderDataType::Float3, "a_Position"},
-        {RHI::ShaderDataType::Float3, "a_Normal"},
-        {RHI::ShaderDataType::Float2, "a_TexCoord"},
-        {RHI::ShaderDataType::Int4, "a_Joints"},
-        {RHI::ShaderDataType::Float4, "a_Weights"}
-    };
-    
+    pipeDesc.vertexLayout = {{RHI::ShaderDataType::Float3, "a_Position"},
+                             {RHI::ShaderDataType::Float3, "a_Normal"},
+                             {RHI::ShaderDataType::Float2, "a_TexCoord"},
+                             {RHI::ShaderDataType::Int4, "a_Joints"},
+                             {RHI::ShaderDataType::Float4, "a_Weights"}};
+
     pipeDesc.pushConstantSize = 192;
     pipeDesc.blendMode = RHI::BlendMode::Alpha;
     pipeDesc.depthTest = true;
@@ -110,7 +108,7 @@ void Renderer3D::Init()
     gridPipeDesc.vertexShader = s_Data3D.GridVertexShader;
     gridPipeDesc.fragmentShader = s_Data3D.GridFragmentShader;
     gridPipeDesc.vertexLayout = {}; // Empty vertex layout, using gl_VertexIndex
-    
+
     gridPipeDesc.pushConstantSize = sizeof(glm::mat4) * 2; // viewProj + inverseViewProj
     gridPipeDesc.blendMode = RHI::BlendMode::Alpha;
     gridPipeDesc.depthTest = true;
@@ -130,7 +128,7 @@ void Renderer3D::Init()
     desc.hostVisible = true;
     s_Data3D.LightStorageBufferHandle = device.CreateBuffer(desc);
     s_Data3D.LightStorageBufferIndex = device.GetBufferBindlessIndex(s_Data3D.LightStorageBufferHandle);
-    
+
     RHI::BufferDesc boneBufferDesc{};
     boneBufferDesc.size = sizeof(glm::mat4) * 4096; // Support up to 4096 bones per frame
     boneBufferDesc.usage = RHI::BufferUsage::Storage;
@@ -145,14 +143,14 @@ void Renderer3D::Shutdown()
     device.DestroyGraphicsPipeline(s_Data3D.ModelPipeline);
     device.DestroyShader(s_Data3D.VertexShader);
     device.DestroyShader(s_Data3D.FragmentShader);
-    
+
     device.DestroyGraphicsPipeline(s_Data3D.GridPipeline);
     device.DestroyShader(s_Data3D.GridVertexShader);
     device.DestroyShader(s_Data3D.GridFragmentShader);
-    
+
     device.DestroyBuffer(s_Data3D.LightStorageBufferHandle);
     device.DestroyBuffer(s_Data3D.BoneStorageBufferHandle);
-    
+
     s_Data3D.WhiteTexture.reset();
 }
 
@@ -163,31 +161,32 @@ void Renderer3D::BeginScene(const EditorCamera& camera, const std::vector<RD3d::
     s_Data3D.CurrentLights = lights;
     if (!lights.empty())
     {
-        Renderer::GetDevice().GetCurrentCommandBuffer().UpdateBuffer(s_Data3D.LightStorageBufferHandle, lights.data(), lights.size() * sizeof(RD3d::LightData));
+        Renderer::GetDevice().GetCurrentCommandBuffer().UpdateBuffer(s_Data3D.LightStorageBufferHandle, lights.data(),
+                                                                     lights.size() * sizeof(RD3d::LightData));
     }
     s_Data3D.BoneBufferOffset = 0;
 }
 
-void Renderer3D::BeginScene(const Camera& camera, const glm::mat4& transform, const std::vector<RD3d::LightData>& lights)
+void Renderer3D::BeginScene(const Camera& camera, const glm::mat4& transform,
+                            const std::vector<RD3d::LightData>& lights)
 {
     s_Data3D.ViewProjection = camera.GetProjection() * glm::inverse(transform);
     s_Data3D.CameraPosition = glm::vec3(transform[3]);
     s_Data3D.CurrentLights = lights;
     if (!lights.empty())
     {
-        Renderer::GetDevice().GetCurrentCommandBuffer().UpdateBuffer(s_Data3D.LightStorageBufferHandle, lights.data(), lights.size() * sizeof(RD3d::LightData));
+        Renderer::GetDevice().GetCurrentCommandBuffer().UpdateBuffer(s_Data3D.LightStorageBufferHandle, lights.data(),
+                                                                     lights.size() * sizeof(RD3d::LightData));
     }
     s_Data3D.BoneBufferOffset = 0;
 }
 
-void Renderer3D::EndScene()
-{
-}
+void Renderer3D::EndScene() {}
 
 void Renderer3D::DrawGrid()
 {
     auto& cmd = Renderer::GetDevice().GetCurrentCommandBuffer();
-    
+
     cmd.BindPipeline(s_Data3D.GridPipeline);
 
     struct GridPushConstants
@@ -197,17 +196,18 @@ void Renderer3D::DrawGrid()
     } pc;
     pc.viewProj = s_Data3D.ViewProjection;
     pc.inverseViewProj = glm::inverse(s_Data3D.ViewProjection);
-    
+
     cmd.PushConstants(RHI::ShaderStage::AllGraphics, &pc, sizeof(GridPushConstants), 0);
 
     // Draw 6 vertices for the full-screen quad (generated by SV_VertexID)
     cmd.Draw(6, 0);
 }
 
-void Renderer3D::SubmitModel(const RD3d::Model& model, const glm::mat4& transform, int entityID, const RD3d::Animator* animator)
+void Renderer3D::SubmitModel(const RD3d::Model& model, const glm::mat4& transform, int entityID,
+                             const RD3d::Animator* animator)
 {
     auto& cmd = Renderer::GetDevice().GetCurrentCommandBuffer();
-    
+
     cmd.BindPipeline(s_Data3D.ModelPipeline);
 
     struct PushConstants
@@ -241,20 +241,21 @@ void Renderer3D::SubmitModel(const RD3d::Model& model, const glm::mat4& transfor
     pc.roughnessFactor = 1.0f;
     pc.boneBufferIndex = -1;
     pc.boneOffset = -1;
-    
+
     if (animator && animator->HasAnimation())
     {
         const auto& matrices = animator->GetFinalBoneMatrices();
         if (!matrices.empty())
         {
             uint64_t size = matrices.size() * sizeof(glm::mat4);
-            cmd.UpdateBuffer(s_Data3D.BoneStorageBufferHandle, matrices.data(), size, s_Data3D.BoneBufferOffset * sizeof(glm::mat4));
+            cmd.UpdateBuffer(s_Data3D.BoneStorageBufferHandle, matrices.data(), size,
+                             s_Data3D.BoneBufferOffset * sizeof(glm::mat4));
             pc.boneBufferIndex = s_Data3D.BoneStorageBufferIndex;
             pc.boneOffset = s_Data3D.BoneBufferOffset;
             s_Data3D.BoneBufferOffset += matrices.size();
         }
     }
-    
+
     // We will push constants per primitive now since textureSlot can change.
     // cmd.PushConstants(RHI::ShaderStage::AllGraphics, &pc, sizeof(PushConstants), 0);
 

--- a/UHE_EDITOR/assets/shaders/Text.slang
+++ b/UHE_EDITOR/assets/shaders/Text.slang
@@ -1,0 +1,91 @@
+struct VertexInput {
+    [[vk::location(0)]] float3 a_Position : POSITION;
+    [[vk::location(1)]] float4 a_Color : COLOR;
+    [[vk::location(2)]] float2 a_TexCoord : TEXCOORD;
+    [[vk::location(3)]] float a_TexIndex : TEXINDEX;
+    [[vk::location(4)]] float a_EntityID : ENTITYID;
+};
+
+struct VertexOutput {
+    float4 location : SV_Position;
+    [[vk::location(0)]] float4 v_Color;
+    [[vk::location(1)]] float2 v_TexCoord;
+    [[vk::location(2)]] nointerpolation float v_TexIndex;
+    [[vk::location(3)]] nointerpolation float v_EntityID;
+};
+
+struct PushConstants {
+    float4x4 viewProjection;
+    int textureIndices[32];
+};
+
+[[vk::push_constant]] ConstantBuffer<PushConstants> pc;
+[[vk::binding(1, 0)]] Sampler2D u_Textures[10000];
+
+float median(float r, float g, float b) {
+    return max(min(r, g), min(max(r, g), b));
+}
+
+[shader("vertex")]
+VertexOutput vertexMain(VertexInput input) {
+    VertexOutput output;
+    output.v_Color = input.a_Color;
+    output.v_TexCoord = input.a_TexCoord;
+    output.v_TexIndex = input.a_TexIndex;
+    output.v_EntityID = input.a_EntityID;
+    output.location = mul(pc.viewProjection, float4(input.a_Position, 1.0));
+    return output;
+}
+
+struct FragmentOutput {
+    [[vk::location(0)]] float4 color : SV_Target0;
+    [[vk::location(1)]] int entityID : SV_Target1;
+};
+
+[shader("fragment")]
+FragmentOutput fragmentMain(VertexOutput input) {
+    FragmentOutput output;
+    int localIndex = (int)round(input.v_TexIndex);
+    float4 texColor = float4(1.0);
+    switch(localIndex) {
+        case 0: texColor = u_Textures[pc.textureIndices[0]].Sample(input.v_TexCoord); break;
+        case 1: texColor = u_Textures[pc.textureIndices[1]].Sample(input.v_TexCoord); break;
+        case 2: texColor = u_Textures[pc.textureIndices[2]].Sample(input.v_TexCoord); break;
+        case 3: texColor = u_Textures[pc.textureIndices[3]].Sample(input.v_TexCoord); break;
+        case 4: texColor = u_Textures[pc.textureIndices[4]].Sample(input.v_TexCoord); break;
+        case 5: texColor = u_Textures[pc.textureIndices[5]].Sample(input.v_TexCoord); break;
+        case 6: texColor = u_Textures[pc.textureIndices[6]].Sample(input.v_TexCoord); break;
+        case 7: texColor = u_Textures[pc.textureIndices[7]].Sample(input.v_TexCoord); break;
+        case 8: texColor = u_Textures[pc.textureIndices[8]].Sample(input.v_TexCoord); break;
+        case 9: texColor = u_Textures[pc.textureIndices[9]].Sample(input.v_TexCoord); break;
+        case 10: texColor = u_Textures[pc.textureIndices[10]].Sample(input.v_TexCoord); break;
+        case 11: texColor = u_Textures[pc.textureIndices[11]].Sample(input.v_TexCoord); break;
+        case 12: texColor = u_Textures[pc.textureIndices[12]].Sample(input.v_TexCoord); break;
+        case 13: texColor = u_Textures[pc.textureIndices[13]].Sample(input.v_TexCoord); break;
+        case 14: texColor = u_Textures[pc.textureIndices[14]].Sample(input.v_TexCoord); break;
+        case 15: texColor = u_Textures[pc.textureIndices[15]].Sample(input.v_TexCoord); break;
+        case 16: texColor = u_Textures[pc.textureIndices[16]].Sample(input.v_TexCoord); break;
+        case 17: texColor = u_Textures[pc.textureIndices[17]].Sample(input.v_TexCoord); break;
+        case 18: texColor = u_Textures[pc.textureIndices[18]].Sample(input.v_TexCoord); break;
+        case 19: texColor = u_Textures[pc.textureIndices[19]].Sample(input.v_TexCoord); break;
+        case 20: texColor = u_Textures[pc.textureIndices[20]].Sample(input.v_TexCoord); break;
+        case 21: texColor = u_Textures[pc.textureIndices[21]].Sample(input.v_TexCoord); break;
+        case 22: texColor = u_Textures[pc.textureIndices[22]].Sample(input.v_TexCoord); break;
+        case 23: texColor = u_Textures[pc.textureIndices[23]].Sample(input.v_TexCoord); break;
+        case 24: texColor = u_Textures[pc.textureIndices[24]].Sample(input.v_TexCoord); break;
+        case 25: texColor = u_Textures[pc.textureIndices[25]].Sample(input.v_TexCoord); break;
+        case 26: texColor = u_Textures[pc.textureIndices[26]].Sample(input.v_TexCoord); break;
+        case 27: texColor = u_Textures[pc.textureIndices[27]].Sample(input.v_TexCoord); break;
+        case 28: texColor = u_Textures[pc.textureIndices[28]].Sample(input.v_TexCoord); break;
+        case 29: texColor = u_Textures[pc.textureIndices[29]].Sample(input.v_TexCoord); break;
+        case 30: texColor = u_Textures[pc.textureIndices[30]].Sample(input.v_TexCoord); break;
+        case 31: texColor = u_Textures[pc.textureIndices[31]].Sample(input.v_TexCoord); break;
+    }
+    float sigDist = median(texColor.r, texColor.g, texColor.b) - 0.5;
+    float alpha = clamp(sigDist / fwidth(sigDist) + 0.5, 0.0, 1.0);
+    float4 finalColor = float4(input.v_Color.rgb, input.v_Color.a * alpha);
+    output.color = finalColor;
+    output.entityID = (int)round(input.v_EntityID);
+    if (finalColor.a < 0.01) discard;
+    return output;
+}

--- a/UHE_EDITOR/assets/shaders/Text.slang
+++ b/UHE_EDITOR/assets/shaders/Text.slang
@@ -80,9 +80,11 @@ FragmentOutput fragmentMain(VertexOutput input) {
         case 29: texColor = u_Textures[pc.textureIndices[29]].Sample(input.v_TexCoord); break;
         case 30: texColor = u_Textures[pc.textureIndices[30]].Sample(input.v_TexCoord); break;
         case 31: texColor = u_Textures[pc.textureIndices[31]].Sample(input.v_TexCoord); break;
+        default: discard;
     }
     float sigDist = median(texColor.r, texColor.g, texColor.b) - 0.5;
-    float alpha = clamp(sigDist / fwidth(sigDist) + 0.5, 0.0, 1.0);
+    float distWidth = fwidth(sigDist);
+    float alpha = distWidth > 0.0 ? clamp(sigDist / distWidth + 0.5, 0.0, 1.0) : (sigDist > 0.0 ? 1.0 : 0.0);
     float4 finalColor = float4(input.v_Color.rgb, input.v_Color.a * alpha);
     output.color = finalColor;
     output.entityID = (int)round(input.v_EntityID);


### PR DESCRIPTION
## Summary

MSDF text rendering groundwork for UHE (Font2D + Text shader), plus Vulkan robustness fixes and a Linux build fix for the vendored ImGui.

### Commits
- `01bce6a Add MSDF text rendering`
  - Vendor **msdf-atlas-gen v1.4** as a git submodule and wire it into the build
  - `Font2D` (`UHE/src/UHE/Renderer/Font.h/.cpp`): runtime MSDF atlas generation, glyph table + UV baking, RHI atlas upload, latin-1 charset, pimpl
  - `Text.slang`: MSDF rasterization (`median()` + `fwidth()` AA) mirroring the `Texture.slang` bindless layout
  - Vulkan robustness: avoid `QuerySupportedFeatures` crash on layered devices, init `VULKAN_HPP_DEFAULT_DISPATCHER`
- `928d95e Fix CodeRabbit review findings; build ImGui directly from CMake`
  - Font2D: FreeType cleanup on all failure paths, atlas-pack failure handled at runtime, atlas texture released via RHI + `Font2D::Shutdown` wired into `Renderer2D::Shutdown`, LCG seed increment, top-origin UV flip, hardware-derived generator thread count, non-copyable/non-movable, invalid fonts not cached
  - `Text.slang`: `default` case in the texture switch + guarded `fwidth()` division
  - `QuerySupportedFeatures`: query into a separate struct so the device feature chain (`m_features2`) only carries explicitly requested features
  - ImGui: the vendored fork's `CMakeLists.txt` defines `IMGUI_API=__declspec(dllexport)` unconditionally and breaks GCC builds — target `ImGui` is now defined in the root `CMakeLists.txt` (MSVC-only export define), submodule left at the published `fe2e7faad`

### Notes
- Runtime atlas generation chosen over CLI baking (no asset pipeline dependency)
- Editor builds and boots clean on Linux/Vulkan (Intel UHD)